### PR TITLE
tooling: Fix `Test` workflow's syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
           cache: true
       - run: go mod download
       - run: go install tool
-        run: ginkgo -r ./...
+      - run: ginkgo -r ./...
         timeout-minutes: 10


### PR DESCRIPTION
The workflow is declaring multiple `run` statements.