### PR TITLE
http/v1: Finalize the HTTP API

### DIFF
--- a/.cspell/dictionary.txt
+++ b/.cspell/dictionary.txt
@@ -6,5 +6,6 @@ goreleaser
 jetstream
 kumomta
 ldflags
+logrecord
 sendsmaily
 trimpath

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 			e.Use(middleware.Recover())
 			e.Use(http.ErrorLogger())
 
-			e.POST("/v1/record", handler)
+			e.POST("/v1/logrecord", handler)
 
 			return e.Start(listenAddr)
 		},


### PR DESCRIPTION
Rename `/v1/record` endpoint to `/v1/logrecord` to improve conformance with KumoMTA's own semantics.